### PR TITLE
New features

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,19 @@ Remember the DDNS key and fill it as password to the config.json.
 
 __NOTICE__: If you have multiple domains or subdomains, make sure their DDNS key are the same.
 
+### Get an IP address from the interface
+
+For some reasons if you want to get an IP directly from the interface, say `eth0` for Linux or `Local Area Connection` for Windows, update config file like this:
+```json
+  "ip_url": "",
+  "ip_interface": "eth0",
+```
+
+If you set both `ip_url` and `ip_interface`, it first tries to get an IP address online, and if not succeed, gets
+an IP address from the interface as a fallback.
+
+Note that IPv6 address will be ignored currently.
+
 ### Email notification support
 
 Update config file and provide your SMTP options, a notification mail will be sent to your mailbox once the IP is changed and updated.  
@@ -241,5 +254,11 @@ Now godns supports to run in docker.
 docker run -d --name godns --restart=always \
 -v /path/to/config.json:/usr/local/godns/config.json timothyye/godns:latest
 ```
+
+## Run it as an Windows service
+
+* Get [birkett/srvany-ng](https://github.com/birkett/srvany-ng/releases) from Github.
+* Uncompress and place the executable `srvany-ng.exe` to the same directory where `godns.exe` in.
+* Create a service and add registry keys according to the guide [here](https://github.com/birkett/srvany-ng).
 
 ## Enjoy it!

--- a/config_sample.json
+++ b/config_sample.json
@@ -19,6 +19,7 @@
     }
   ],
   "ip_url": "http://members.3322.org/dyndns/getip",
+  "ip_interface": "eth0",
   "socks5_proxy": "",
   "notify": {
     "enabled": false,

--- a/settings.go
+++ b/settings.go
@@ -33,6 +33,9 @@ type Settings struct {
 	LogPath     string   `json:"log_path"`
 	Socks5Proxy string   `json:"socks5_proxy"`
 	Notify      Notify   `json:"notify"`
+	IPInterface string   `json:"ip_interface"`
+	//the code is not ready to update AAAA record
+	//IPType      string   `json:"ip_type"`
 }
 
 // LoadSettings -- Load settings from config file


### PR DESCRIPTION
- Add support for getting an IP from an interface
- Skip DNS record updating if the IP address is the same with last one
Note that most DNS provider will ban your account from updating through the API if you keep updating *A SAME* IP address, such as HE.NET.
- Update document for getting an IP from an interface and running as a Windows service

Tested with HE.net and Windows. It works.