### PR TITLE
Better DNSPod error message handling and ip_type checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ For DNSPod, you need to provide your API Token(you can create it [here](https://
     }
   ],
   "ip_url": "https://myip.biturl.top",
+  "ip_type": "IPV4",
   "interval": 300,
   "socks5_proxy": ""
 }

--- a/handler/dnspod/dnspod_handler.go
+++ b/handler/dnspod/dnspod_handler.go
@@ -216,6 +216,9 @@ func (handler *Handler) UpdateIP(domainID int64, subDomainID string, subDomainNa
 		value.Add("record_type", "A")
 	} else if strings.ToUpper(handler.Configuration.IPType) == godns.IPV6 {
 		value.Add("record_type", "AAAA")
+	} else {
+		log.Println("Error: must specify \"ip_type\" in config for DNSPod.");
+		return
 	}
 
 	value.Add("record_line", "默认")
@@ -238,6 +241,8 @@ func (handler *Handler) UpdateIP(domainID int64, subDomainID string, subDomainNa
 
 	if sjson.Get("status").Get("code").MustString() == "1" {
 		log.Println("New IP updated!")
+	} else {
+		log.Println("Failed to update IP record:", sjson.Get("status").Get("message").MustString())
 	}
 
 }


### PR DESCRIPTION
DNSPod API now requires record type to be specified, so the `ip_type`
setting must be set in config.json. Otherwise DNSPod will return error
message like this: 
> {"status":{"code":"27","message":"Record type invalid","created_at":"2020-02-09 02:59:10"}}

This PR also prints out error message if DNSPod returns any non success result.
