### PR TITLE
proxy should not be used while getting public ip

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -159,19 +159,6 @@ func GetCurrentIP(configuration *Settings) (string, error) {
 func GetIPOnline(configuration *Settings) (string, error) {
 	client := &http.Client{}
 
-	if configuration.Socks5Proxy != "" {
-		log.Println("use socks5 proxy:" + configuration.Socks5Proxy)
-		dialer, err := proxy.SOCKS5("tcp", configuration.Socks5Proxy, nil, proxy.Direct)
-		if err != nil {
-			log.Println("can't connect to the proxy:", err)
-			return "", err
-		}
-
-		httpTransport := &http.Transport{}
-		client.Transport = httpTransport
-		httpTransport.Dial = dialer.Dial
-	}
-
 	var response *http.Response
 	var err error
 


### PR DESCRIPTION
remove proxy while getting public ip , otherwise ip of socks server would be returned