### PR TITLE
enable socks for domain update and telegram notification seperately

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,8 @@ Update config file and provide your Telegram options, a notification message wil
       "enabled": true,
       "bot_api_key": "11111:aaaa-bbbb",
       "chat_id": "-123456",
-      "message_template": "Domain *{{ .Domain }}* is updated to %0A{{ .CurrentIP }}"
+      "message_template": "Domain *{{ .Domain }}* is updated to %0A{{ .CurrentIP }}",
+      "use_proxy": false
     },
   }
 ```
@@ -410,6 +411,7 @@ You can also use SOCKS5 proxy, just fill SOCKS5 address to the ```socks5_proxy``
 
 ```json
 "socks5_proxy": "127.0.0.1:7070"
+"use_proxy": true
 ```
 
 Now all the queries will go through the specified SOCKS5 proxy.

--- a/config_sample.json
+++ b/config_sample.json
@@ -26,12 +26,14 @@
   "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.111 Safari/537.36",
   "ip_interface": "eth0",
   "socks5_proxy": "",
+  "use_proxy": false,
   "notify": {
     "telegram": {
       "enabled": false,
       "bot_api_key": "",
       "chat_id": "",
-      "message_template": ""
+      "message_template": "",
+      "use_proxy": false
     },
     "mail": {
       "enabled": false,

--- a/handler/alidns/alidns_handler.go
+++ b/handler/alidns/alidns_handler.go
@@ -28,9 +28,17 @@ func (handler *Handler) DomainLoop(domain *godns.Domain, panicChan chan<- godns.
 		}
 	}()
 
+	looping := false
 	aliDNS := NewAliDNS(handler.Configuration.Email, handler.Configuration.Password)
 
 	for {
+		if looping {
+			// Sleep with interval
+			log.Printf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
+			time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
+		}
+
+		looping = true
 		currentIP, err := godns.GetCurrentIP(handler.Configuration)
 
 		if err != nil {
@@ -68,9 +76,6 @@ func (handler *Handler) DomainLoop(domain *godns.Domain, panicChan chan<- godns.
 				}
 			}
 		}
-		// Sleep with interval
-		log.Printf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
-		time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 	}
 
 }

--- a/handler/cloudflare/cloudflare_handler.go
+++ b/handler/cloudflare/cloudflare_handler.go
@@ -77,7 +77,15 @@ func (handler *Handler) DomainLoop(domain *godns.Domain, panicChan chan<- godns.
 	}()
 
 	var lastIP string
+	looping := false
 	for {
+		if looping {
+			// Sleep with interval
+			log.Printf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
+			time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
+		}
+		looping = true
+
 		currentIP, err := godns.GetCurrentIP(handler.Configuration)
 		if err != nil {
 			log.Println("Error in GetCurrentIP:", err)
@@ -117,9 +125,6 @@ func (handler *Handler) DomainLoop(domain *godns.Domain, panicChan chan<- godns.
 				log.Println("Failed to find zone for domain:", domain.DomainName)
 			}
 		}
-		// Sleep with interval
-		log.Printf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
-		time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 	}
 }
 
@@ -137,7 +142,7 @@ func recordTracked(domain *godns.Domain, record *DNSRecord) bool {
 
 // Create a new request with auth in place and optional proxy
 func (handler *Handler) newRequest(method, url string, body io.Reader) (*http.Request, *http.Client) {
-	client := godns.GetHttpClient(handler.Configuration)
+	client := godns.GetHttpClient(handler.Configuration, handler.Configuration.UseProxy)
 	if client == nil {
 		log.Println("cannot create HTTP client")
 	}

--- a/handler/dnspod/dnspod_handler.go
+++ b/handler/dnspod/dnspod_handler.go
@@ -36,7 +36,16 @@ func (handler *Handler) DomainLoop(domain *godns.Domain, panicChan chan<- godns.
 		}
 	}()
 
+	looping := false
 	for {
+		if looping {
+			// Sleep with interval
+			log.Printf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
+			time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
+		}
+
+		looping = true
+
 		log.Printf("Checking IP for domain %s \r\n", domain.DomainName)
 		domainID := handler.GetDomain(domain.DomainName)
 
@@ -82,9 +91,6 @@ func (handler *Handler) DomainLoop(domain *godns.Domain, panicChan chan<- godns.
 				}
 			}
 		}
-		// Sleep with interval
-		log.Printf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
-		time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 	}
 }
 
@@ -245,7 +251,7 @@ func (handler *Handler) UpdateIP(domainID int64, subDomainID string, subDomainNa
 
 // PostData post data and invoke DNSPod API
 func (handler *Handler) PostData(url string, content url.Values) (string, error) {
-	client := godns.GetHttpClient(handler.Configuration)
+	client := godns.GetHttpClient(handler.Configuration, handler.Configuration.UseProxy)
 
 	if client == nil {
 		return "", errors.New("failed to create HTTP client")

--- a/handler/dreamhost/dreamhost_handler.go
+++ b/handler/dreamhost/dreamhost_handler.go
@@ -38,7 +38,15 @@ func (handler *Handler) DomainLoop(domain *godns.Domain, panicChan chan<- godns.
 		}
 	}()
 
+	looping := false
 	for {
+		if looping {
+			// Sleep with interval
+			log.Printf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
+			time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
+		}
+		looping = true
+
 		currentIP, err := godns.GetCurrentIP(handler.Configuration)
 
 		if err != nil {
@@ -63,10 +71,6 @@ func (handler *Handler) DomainLoop(domain *godns.Domain, panicChan chan<- godns.
 				}
 			}
 		}
-
-		// Sleep with interval
-		log.Printf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
-		time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 	}
 
 }
@@ -106,7 +110,7 @@ func (handler *Handler) updateDNS(dns, ip, hostname, action string) {
 		log.Fatalf("Unknown action %s\n", action)
 	}
 
-	client := godns.GetHttpClient(handler.Configuration)
+	client := godns.GetHttpClient(handler.Configuration, handler.Configuration.UseProxy)
 	req, _ := http.NewRequest("POST", DreamhostURL, strings.NewReader(values.Encode()))
 	req.SetBasicAuth(handler.Configuration.Email, handler.Configuration.Password)
 

--- a/handler/duck/duck_handler.go
+++ b/handler/duck/duck_handler.go
@@ -35,7 +35,16 @@ func (handler *Handler) DomainLoop(domain *godns.Domain, panicChan chan<- godns.
 		}
 	}()
 
+	looping := false
+
 	for {
+		if looping {
+			// Sleep with interval
+			log.Printf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
+			time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
+		}
+
+		looping = true
 		currentIP, err := godns.GetCurrentIP(handler.Configuration)
 
 		if err != nil {
@@ -46,7 +55,7 @@ func (handler *Handler) DomainLoop(domain *godns.Domain, panicChan chan<- godns.
 
 		//check against locally cached IP, if no change, skip update
 
-		client := godns.GetHttpClient(handler.Configuration)
+		client := godns.GetHttpClient(handler.Configuration, handler.Configuration.UseProxy)
 		var ip string
 
 		if strings.ToUpper(handler.Configuration.IPType) == godns.IPV4 {
@@ -86,9 +95,5 @@ func (handler *Handler) DomainLoop(domain *godns.Domain, panicChan chan<- godns.
 				}
 			}
 		}
-
-		// Sleep with interval
-		log.Printf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
-		time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 	}
 }

--- a/handler/google/google_handler.go
+++ b/handler/google/google_handler.go
@@ -36,7 +36,16 @@ func (handler *Handler) DomainLoop(domain *godns.Domain, panicChan chan<- godns.
 		}
 	}()
 
+	looping := false
+
 	for {
+		if looping {
+			// Sleep with interval
+			log.Printf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
+			time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
+		}
+
+		looping = true
 		currentIP, err := godns.GetCurrentIP(handler.Configuration)
 		if err != nil {
 			log.Println("get_currentIP:", err)
@@ -59,16 +68,13 @@ func (handler *Handler) DomainLoop(domain *godns.Domain, panicChan chan<- godns.
 				}
 			}
 		}
-		// Sleep with interval
-		log.Printf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
-		time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 	}
 
 }
 
 // UpdateIP update subdomain with current IP
 func (handler *Handler) UpdateIP(domain, subDomain, currentIP string) {
-	client := godns.GetHttpClient(handler.Configuration)
+	client := godns.GetHttpClient(handler.Configuration, handler.Configuration.UseProxy)
 	resp, err := client.Get(fmt.Sprintf(GoogleURL,
 		handler.Configuration.Email,
 		handler.Configuration.Password,

--- a/handler/he/he_handler.go
+++ b/handler/he/he_handler.go
@@ -37,7 +37,15 @@ func (handler *Handler) DomainLoop(domain *godns.Domain, panicChan chan<- godns.
 		}
 	}()
 
+	looping := false
 	for {
+		if looping {
+			// Sleep with interval
+			log.Printf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
+			time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
+		}
+		looping = true
+
 		currentIP, err := godns.GetCurrentIP(handler.Configuration)
 
 		if err != nil {
@@ -64,10 +72,6 @@ func (handler *Handler) DomainLoop(domain *godns.Domain, panicChan chan<- godns.
 				}
 			}
 		}
-
-		// Sleep with interval
-		log.Printf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
-		time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 	}
 
 }
@@ -79,7 +83,7 @@ func (handler *Handler) UpdateIP(domain, subDomain, currentIP string) {
 	values.Add("password", handler.Configuration.Password)
 	values.Add("myip", currentIP)
 
-	client := godns.GetHttpClient(handler.Configuration)
+	client := godns.GetHttpClient(handler.Configuration, handler.Configuration.UseProxy)
 
 	req, _ := http.NewRequest("POST", HEUrl, strings.NewReader(values.Encode()))
 	resp, err := client.Do(req)

--- a/settings.go
+++ b/settings.go
@@ -18,6 +18,7 @@ type TelegramNotify struct {
 	BotApiKey   string `json:"bot_api_key"`
 	ChatId      string `json:"chat_id"`
 	MsgTemplate string `json:"message_template"`
+	UseProxy    bool   `json:"use_proxy"`
 }
 
 // Notify struct for SMTP notification
@@ -53,6 +54,7 @@ type Settings struct {
 	IPInterface string   `json:"ip_interface"`
 	IPType      string   `json:"ip_type"`
 	Resolver    string   `json:"resolver"`
+	UseProxy    bool     `json:"use_proxy"`
 }
 
 // LoadSettings -- Load settings from config file

--- a/utils.go
+++ b/utils.go
@@ -95,7 +95,7 @@ func GetIPFromInterface(configuration *Settings) (string, error) {
 		}
 
 		if isIPv4(ip.String()) {
-			if strings.ToUpper(configuration.IPType) == IPV4 {
+			if strings.ToUpper(configuration.IPType) != IPV4 {
 				continue
 			}
 		} else {

--- a/utils.go
+++ b/utils.go
@@ -116,10 +116,10 @@ func isIPv4(ip string) bool {
 }
 
 // GetHttpClient creates the HTTP client and return it
-func GetHttpClient(configuration *Settings) *http.Client {
+func GetHttpClient(configuration *Settings, use_proxy bool) *http.Client {
 	client := &http.Client{}
 
-	if configuration.Socks5Proxy != "" {
+	if use_proxy && configuration.Socks5Proxy != "" {
 		log.Println("use socks5 proxy:" + configuration.Socks5Proxy)
 		dialer, err := proxy.SOCKS5("tcp", configuration.Socks5Proxy, nil, proxy.Direct)
 		if err != nil {
@@ -249,7 +249,7 @@ func SendTelegramNotify(configuration *Settings, domain, currentIP string) error
 		return errors.New("chat id cannot be empty")
 	}
 
-	client := GetHttpClient(configuration)
+	client := GetHttpClient(configuration, configuration.Notify.Telegram.UseProxy)
 	tpl := configuration.Notify.Telegram.MsgTemplate
 	if tpl == "" {
 		tpl = "_Your IP address is changed to_%0A%0A*{{ .CurrentIP }}*%0A%0ADomain *{{ .Domain }}* is updated"


### PR DESCRIPTION
- add configuration to enable socks for domain update
  and telegram notification seperately.
- sleep to reduce cpu usage while connection error occurred.

if error happened, directly `continue` the loop will cause high cpu usage.