### PR TITLE
Let docker can change to correct timezone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /godns
 RUN go build -o godns cmd/godns/godns.go
 
 FROM alpine
-RUN apk add --update ca-certificates
+RUN apk add --no-cache ca-certificates tzdata
 RUN mkdir /usr/local/godns
 COPY --from=builder /godns/godns /usr/local/godns
 RUN chmod +x /usr/local/godns/godns


### PR DESCRIPTION
The current version of the docker image does not respond correctly to the “TZ” environment variable, causing the log time that do not match the local time. We just need to add tzdata package to solve this problem.
A little improvement to user experience.