### PR TITLE
Fix API token permission issue with CloudFlare

### DIFF
--- a/handler/cloudflare/cloudflare_handler.go
+++ b/handler/cloudflare/cloudflare_handler.go
@@ -163,7 +163,7 @@ func (handler *Handler) getZone(domain string) string {
 
 	var z ZoneResponse
 
-	req, client := handler.newRequest("GET", "/zones", nil)
+	req, client := handler.newRequest("GET", fmt.Sprintf("/zones?name=%s", domain), nil)
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Println("Request error:", err.Error())


### PR DESCRIPTION
When querying CloudFlare for all zones via the API using a restricted API token, CloudFlare responds, that that particular token needs the "com.cloudflare.api.account.zone.list" permission (which you are not able to assign), in order to successfully retrieve all zones.
Adding the parameter `name` with the value of the given domain works around that limitation, as then the API token only needs access to that particular domain.

This pull request fixes any issues with API tokens configured like this:

![image](https://user-images.githubusercontent.com/2050966/98408718-ee84b580-2071-11eb-80eb-dcbb25fb3dbb.png)
