### PR TITLE
feat: Add support for discord notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Currently supports updating A records for subdomains. Doesn't support updating o
     - [Email](#email)
     - [Telegram](#telegram)
     - [Slack](#slack)
+    - [Discord](#discord)
   - [Miscellaneous topics](#miscellaneous-topics)
     - [IPv6 support](#ipv6-support)
     - [Network interface IP address](#network-interface-ip-address)
@@ -491,6 +492,21 @@ To receive a [Slack](https://slack.com) message each time the IP changes, update
       "message_template": "Domain *{{ .Domain }}* is updated to \n{{ .CurrentIP }}",
       "use_proxy": false
     },
+  }
+```
+
+#### Discord
+
+To receive a [Discord](https://discord.gg) message each time the IP changes, update your configuration with the following snippit:
+
+```json
+  "notify": {
+    "discord": {
+          "enabled": true,
+          "bot_api_token": "discord_bot_token",
+          "channel": "your_channel",
+          "message_template": "(Optional) Domain *{{ .Domain }}* is updated to \n{{ .CurrentIP }}",
+        }
   }
 ```
 

--- a/README.md
+++ b/README.md
@@ -495,6 +495,8 @@ To receive a [Slack](https://slack.com) message each time the IP changes, update
   }
 ```
 
+The `message_template` property supports [markdown](https://www.markdownguide.org). New lines needs to be escaped with `\n`.
+
 #### Discord
 
 To receive a [Discord](https://discord.gg) message each time the IP changes, update your configuration with the following snippit:
@@ -509,8 +511,6 @@ To receive a [Discord](https://discord.gg) message each time the IP changes, upd
         }
   }
 ```
-
-The `message_template` property supports [markdown](https://www.markdownguide.org). New lines needs to be escaped with `\n`.
 
 ### Miscellaneous topics
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/bitly/go-simplejson v0.5.0
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/bogdanovich/dns_resolver v0.0.0-20170211073258-a8e42bc6a5b6 // indirect
+	github.com/bwmarrin/discordgo v0.23.2
 	github.com/fatih/color v1.7.0
 	github.com/google/uuid v1.1.1
 	github.com/kr/pretty v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,14 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4Yn
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bogdanovich/dns_resolver v0.0.0-20170211073258-a8e42bc6a5b6 h1:oV1V+uwP+sjmdSkvMxsl/l+HE+N8wbL49wCXZPel25M=
 github.com/bogdanovich/dns_resolver v0.0.0-20170211073258-a8e42bc6a5b6/go.mod h1:txOV61Nn+21z77KUMkNsp8lTHoOFTtqotltQAFenS9I=
+github.com/bwmarrin/discordgo v0.23.2 h1:BzrtTktixGHIu9Tt7dEE6diysEF9HWnXeHuoJEt2fH4=
+github.com/bwmarrin/discordgo v0.23.2/go.mod h1:c1WtWUGN6nREDmzIpyTp/iD3VYt4Fpx+bVyfBG7JE+M=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
+github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -19,6 +23,7 @@ github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/miekg/dns v1.1.29 h1:xHBEhR+t5RzcFJjBLJlax2daXOrTYtr9z4WdKEfWFzg=
 github.com/miekg/dns v1.1.29/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
+golang.org/x/crypto v0.0.0-20181030102418-4d3f4d9ffa16/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/notify/discord.go
+++ b/notify/discord.go
@@ -17,12 +17,12 @@ func NewDiscordNotify(conf *godns.Settings) INotify {
 
 func (n *DiscordNotify) Send(domain, currentIP string) error {
 
-	if n.conf.Notify.Discord.BotApiKey == "" {
-		return errors.New("bot api key cannot be empty")
+	if n.conf.Notify.Discord.BotApiToken == "" {
+		return errors.New("bot api token cannot be empty")
 	}
 
 	if n.conf.Notify.Discord.Channel == "" {
-		return errors.New("bot channel id cannot be empty")
+		return errors.New("channel id cannot be empty")
 	}
 
 	tpl := n.conf.Notify.Discord.MsgTemplate
@@ -32,7 +32,7 @@ func (n *DiscordNotify) Send(domain, currentIP string) error {
 	msg := buildTemplate(currentIP, domain, tpl)
 
 	//Create discordgo client
-	d, err := discordgo.New("Bot " + n.conf.Notify.Discord.BotApiKey)
+	d, err := discordgo.New("Bot " + n.conf.Notify.Discord.BotApiToken)
 	if err != nil {
 		return errors.New("error creating discord bot")
 	}

--- a/notify/discord.go
+++ b/notify/discord.go
@@ -1,0 +1,55 @@
+package notify
+
+import (
+	"errors"
+
+	"github.com/TimothyYe/godns"
+	"github.com/bwmarrin/discordgo"
+)
+
+type DiscordNotify struct {
+	conf *godns.Settings
+}
+
+func NewDiscordNotify(conf *godns.Settings) INotify {
+	return &DiscordNotify{conf: conf}
+}
+
+func (n *DiscordNotify) Send(domain, currentIP string) error {
+
+	if n.conf.Notify.Discord.BotApiKey == "" {
+		return errors.New("bot api key cannot be empty")
+	}
+
+	if n.conf.Notify.Discord.Channel == "" {
+		return errors.New("bot channel id cannot be empty")
+	}
+
+	tpl := n.conf.Notify.Discord.MsgTemplate
+	if tpl == "" {
+		tpl = "Your IP address for {{.Domain}} has been updated to {{ .CurrentIP }} "
+	}
+	msg := buildTemplate(currentIP, domain, tpl)
+
+	//Create discordgo client
+	d, err := discordgo.New("Bot " + n.conf.Notify.Discord.BotApiKey)
+	if err != nil {
+		return errors.New("error creating discord bot")
+	}
+	//Open socket connection
+	err = d.Open()
+	if err != nil {
+		return errors.New("error opening connection,")
+	}
+	//Send message
+	_, err = d.ChannelMessageSend(n.conf.Notify.Discord.Channel, msg)
+	if err != nil {
+		return errors.New("error sending message")
+	}
+	//Close socket connection
+	err = d.Close()
+	if err != nil {
+		return errors.New("error closing discord connection")
+	}
+	return nil
+}

--- a/notify/manager.go
+++ b/notify/manager.go
@@ -11,6 +11,7 @@ const (
 	Email    = "email"
 	Slack    = "slack"
 	Telegram = "telegram"
+	Discord  = "discord"
 )
 
 var (
@@ -51,6 +52,10 @@ func initNotifications(conf *godns.Settings) map[string]INotify {
 		notifyMap[Telegram] = NewTelegramNotify(conf)
 	}
 
+	if conf.Notify.Discord.Enabled {
+		notifyMap[Discord] = NewDiscordNotify(conf)
+	}
+	
 	return notifyMap
 }
 

--- a/settings.go
+++ b/settings.go
@@ -42,7 +42,7 @@ type MailNotify struct {
 
 type DiscordNotify struct {
 	Enabled     bool   `json:"enabled"`
-	BotApiKey   string `json:"bot_api_key"`
+	BotApiToken string `json:"bot_api_token"`
 	Channel     string `json:"channel"`
 	MsgTemplate string `json:"message_template"`
 }

--- a/settings.go
+++ b/settings.go
@@ -15,8 +15,8 @@ type Domain struct {
 // Notify struct for slack notification
 type SlackNotify struct {
 	Enabled     bool   `json:"enabled"`
-	BotApiToken   string `json:"bot_api_token"`
-	Channel      string `json:"channel"`
+	BotApiToken string `json:"bot_api_token"`
+	Channel     string `json:"channel"`
 	MsgTemplate string `json:"message_template"`
 	UseProxy    bool   `json:"use_proxy"`
 }
@@ -40,11 +40,19 @@ type MailNotify struct {
 	SendTo       string `json:"send_to"`
 }
 
+type DiscordNotify struct {
+	Enabled     bool   `json:"enabled"`
+	BotApiKey   string `json:"bot_api_key"`
+	Channel     string `json:"channel"`
+	MsgTemplate string `json:"message_template"`
+}
+
 // Notify struct
 type Notify struct {
 	Telegram TelegramNotify `json:"telegram"`
 	Mail     MailNotify     `json:"mail"`
-	Slack	 SlackNotify	`json:"slack"`
+	Slack    SlackNotify    `json:"slack"`
+	Discord  DiscordNotify  `json:"discord"`
 }
 
 // Settings struct


### PR DESCRIPTION
Added support for discord notifications. 
Unlike telegram and slack, discord seems to require creating a websocket connection before allowing messages to be sent using its API. To help facilitate this I used the [discordgo](https://github.com/bwmarrin/discordgo) library. 

A connection is created and closed each time a message is sent, so there might be room for some improvement there?. 
