### PR TITLE
GetCurrentIP error is shadowed during return

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -124,9 +124,10 @@ func isIPv4(ip string) bool {
 //GetCurrentIP gets an IP from either internet or specific interface, depending on configuration
 func GetCurrentIP(configuration *Settings) (string, error) {
 	var err error
+	var ip string
 
 	if configuration.IPUrl != "" || configuration.IPV6Url != "" {
-		ip, err := GetIPOnline(configuration)
+		ip, err = GetIPOnline(configuration)
 		if err != nil {
 			log.Println("get ip online failed. Fallback to get ip from interface if possible.")
 		} else {
@@ -135,7 +136,7 @@ func GetCurrentIP(configuration *Settings) (string, error) {
 	}
 
 	if configuration.IPInterface != "" {
-		ip, err := GetIPFromInterface(configuration)
+		ip, err = GetIPFromInterface(configuration)
 		if err != nil {
 			log.Println("get ip from interface failed. There is no more ways to try.")
 		} else {


### PR DESCRIPTION
These days I always accept the following email, where IP is empty.

![image](https://user-images.githubusercontent.com/16044915/117391463-90526580-af22-11eb-96a6-52a29672deda.png)

Checked the logs and found that the program didn't get my IP address correctly.

```
[GoDNS] 2021/05/07 10:36:12 Cannot get IP...
[GoDNS] 2021/05/07 10:36:12 get ip online failed. Fallback to get ip from interface if possible.
[GoDNS] 2021/05/07 10:36:12 currentIP is:
[GoDNS] 2021/05/07 10:36:12 debug: 71446907 h
[GoDNS] 2021/05/07 10:36:12 h.razeen.cn Start to update record IP...
[GoDNS] 2021/05/07 10:36:12 Sending notification to:xxxxxx
```
But  it doesn't have to email me.

So I reviewed the code and found that the error here was not returned correctly.