### PR TITLE
Logging tweaks - moving to formatted logging (from Info to Infof) and adding whitespaces where necessary.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ _testmain.go
 *.swp
 *.gz
 godns
+!godns/ # Don't ignore the godns directory, only the file
 godns.exe
 config.json
 cmd/godns/config.json

--- a/cmd/godns/godns.go
+++ b/cmd/godns/godns.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	"github.com/TimothyYe/godns/internal/handler"
 	"github.com/TimothyYe/godns/internal/settings"
 	"github.com/TimothyYe/godns/internal/utils"
-	"os"
 
 	log "github.com/sirupsen/logrus"
 
@@ -57,7 +57,7 @@ func main() {
 func dnsLoop() {
 	panicChan := make(chan settings.Domain)
 
-	log.Info("Creating DNS handler with provider:", configuration.Provider)
+	log.Infof("Creating DNS handler with provider: %s", configuration.Provider)
 	h := handler.CreateHandler(configuration.Provider)
 	h.SetConfiguration(&configuration)
 	for _, domain := range configuration.Domains {

--- a/internal/handler/alidns/alidns_handler.go
+++ b/internal/handler/alidns/alidns_handler.go
@@ -26,7 +26,7 @@ func (handler *Handler) SetConfiguration(conf *settings.Settings) {
 func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- settings.Domain, runOnce bool) {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Errorf("Recovered in %v: %v\n", err, string(debug.Stack()))
+			log.Errorf("Recovered in %v: %v", err, string(debug.Stack()))
 			panicChan <- *domain
 		}
 	}()
@@ -37,7 +37,7 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 	for while := true; while; while = !runOnce {
 		if looping {
 			// Sleep with interval
-			log.Debugf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
+			log.Debugf("Going to sleep, will start next checking in %d seconds...", handler.Configuration.Interval)
 			time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 		}
 
@@ -64,23 +64,23 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 			}
 			//check against currently known IP, if no change, skip update
 			if currentIP == lastIP {
-				log.Infof("IP is the same as cached one (%s). Skip update.\n", currentIP)
+				log.Infof("IP is the same as cached one (%s). Skip update.", currentIP)
 			} else {
 				lastIP = currentIP
 
-				log.Infof("%s.%s - Start to update record IP...\n", subDomain, domain.DomainName)
+				log.Infof("%s.%s - Start to update record IP...", subDomain, domain.DomainName)
 				records := aliDNS.GetDomainRecords(domain.DomainName, subDomain)
 				if records == nil || len(records) == 0 {
-					log.Infof("Cannot get subdomain %s from AliDNS.\r\n", subDomain)
+					log.Infof("Cannot get subdomain %s from AliDNS.", subDomain)
 					continue
 				}
 
 				records[0].Value = currentIP
 				if err := aliDNS.UpdateDomainRecord(records[0]); err != nil {
-					log.Infof("Failed to update IP for subdomain:%s\r\n", subDomain)
+					log.Infof("Failed to update IP for subdomain:%s", subDomain)
 					continue
 				} else {
-					log.Infof("IP updated for subdomain:%s\r\n", subDomain)
+					log.Infof("IP updated for subdomain:%s", subDomain)
 				}
 
 				// Send notification

--- a/internal/handler/cloudflare/cloudflare_handler.go
+++ b/internal/handler/cloudflare/cloudflare_handler.go
@@ -74,7 +74,7 @@ func (handler *Handler) SetConfiguration(conf *settings.Settings) {
 func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- settings.Domain, runOnce bool) {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Errorf("Recovered in %v: %v\n", err, string(debug.Stack()))
+			log.Errorf("Recovered in %v: %v", err, string(debug.Stack()))
 			panicChan <- *domain
 		}
 	}()
@@ -84,7 +84,7 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 	for while := true; while; while = !runOnce {
 		if looping {
 			// Sleep with interval
-			log.Debugf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
+			log.Debugf("Going to sleep, will start next checking in %d seconds...", handler.Configuration.Interval)
 			time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 		}
 		looping = true
@@ -97,9 +97,9 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 		log.Debug("Current IP is:", currentIP)
 		//check against locally cached IP, if no change, skip update
 		if currentIP == lastIP {
-			log.Infof("IP is the same as cached one (%s). Skip update.\n", currentIP)
+			log.Infof("IP is the same as cached one (%s). Skip update.", currentIP)
 		} else {
-			log.Info("Checking IP for domain ", domain.DomainName)
+			log.Infof("Checking IP for domain %s", domain.DomainName)
 			zoneID := handler.getZone(domain.DomainName)
 			if zoneID != "" {
 				records := handler.getDNSRecords(zoneID)
@@ -111,17 +111,17 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 						continue
 					}
 					if rec.IP != currentIP {
-						log.Infof("IP mismatch: Current(%+v) vs Cloudflare(%+v)\r\n", currentIP, rec.IP)
+						log.Infof("IP mismatch: Current(%+v) vs Cloudflare(%+v)", currentIP, rec.IP)
 						lastIP = handler.updateRecord(rec, currentIP)
 
 						// Send notification
 						notify.GetNotifyManager(handler.Configuration).Send(rec.Name, currentIP)
 					} else {
-						log.Infof("Record OK: %+v - %+v\r\n", rec.Name, rec.IP)
+						log.Infof("Record OK: %+v - %+v", rec.Name, rec.IP)
 					}
 				}
 			} else {
-				log.Info("Failed to find zone for domain:", domain.DomainName)
+				log.Infof("Failed to find zone for domain: %s", domain.DomainName)
 			}
 		}
 	}
@@ -176,12 +176,12 @@ func (handler *Handler) getZone(domain string) string {
 	body, _ := ioutil.ReadAll(resp.Body)
 	err = json.Unmarshal(body, &z)
 	if err != nil {
-		log.Errorf("Decoder error: %+v\n", err)
-		log.Debugf("Response body: %+v\n", string(body))
+		log.Errorf("Decoder error: %+v", err)
+		log.Debugf("Response body: %+v", string(body))
 		return ""
 	}
 	if z.Success != true {
-		log.Infof("Response failed: %+v\n", string(body))
+		log.Infof("Response failed: %+v", string(body))
 		return ""
 	}
 
@@ -206,7 +206,7 @@ func (handler *Handler) getDNSRecords(zoneID string) []DNSRecord {
 		recordType = utils.IPTypeAAAA
 	}
 
-	log.Info("Querying records with type:", recordType)
+	log.Infof("Querying records with type: %s", recordType)
 	req, client := handler.newRequest("GET", fmt.Sprintf("/zones/"+zoneID+"/dns_records?type=%s&page=1&per_page=500", recordType), nil)
 	resp, err := client.Do(req)
 	if err != nil {
@@ -217,13 +217,13 @@ func (handler *Handler) getDNSRecords(zoneID string) []DNSRecord {
 	body, _ := ioutil.ReadAll(resp.Body)
 	err = json.Unmarshal(body, &r)
 	if err != nil {
-		log.Infof("Decoder error: %+v\n", err)
-		log.Debugf("Response body: %+v\n", string(body))
+		log.Infof("Decoder error: %+v", err)
+		log.Debugf("Response body: %+v", string(body))
 		return empty
 	}
 	if r.Success != true {
 		body, _ := ioutil.ReadAll(resp.Body)
-		log.Infof("Response failed: %+v\n", string(body))
+		log.Infof("Response failed: %+v", string(body))
 		return empty
 
 	}
@@ -251,13 +251,13 @@ func (handler *Handler) updateRecord(record DNSRecord, newIP string) string {
 	body, _ := ioutil.ReadAll(resp.Body)
 	err = json.Unmarshal(body, &r)
 	if err != nil {
-		log.Errorf("Decoder error: %+v\n", err)
-		log.Debugf("Response body: %+v\n", string(body))
+		log.Errorf("Decoder error: %+v", err)
+		log.Debugf("Response body: %+v", string(body))
 		return ""
 	}
 	if r.Success != true {
 		body, _ := ioutil.ReadAll(resp.Body)
-		log.Infof("Response failed: %+v\n", string(body))
+		log.Infof("Response failed: %+v", string(body))
 	} else {
 		log.Infof("Record updated: %+v - %+v", record.Name, record.IP)
 		lastIP = record.IP

--- a/internal/handler/cloudflare/cloudflare_handler_test.go
+++ b/internal/handler/cloudflare/cloudflare_handler_test.go
@@ -2,9 +2,10 @@ package cloudflare
 
 import (
 	"encoding/json"
-	"github.com/TimothyYe/godns/internal/settings"
 	"strings"
 	"testing"
+
+	"github.com/TimothyYe/godns/internal/settings"
 )
 
 func TestResponseToJSON(t *testing.T) {
@@ -160,7 +161,7 @@ func TestRecordTracked(t *testing.T) {
 
 	for _, rec := range resp.Records {
 		if recordTracked(domain, &rec) {
-			t.Logf("Record founded: %+v\r\n", rec.Name)
+			t.Logf("Record founded: %+v", rec.Name)
 		}
 	}
 }

--- a/internal/handler/dnspod/dnspod_handler.go
+++ b/internal/handler/dnspod/dnspod_handler.go
@@ -35,7 +35,7 @@ func (handler *Handler) SetConfiguration(conf *settings.Settings) {
 func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- settings.Domain, runOnce bool) {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Errorf("Recovered in %v: %v\n", err, string(debug.Stack()))
+			log.Errorf("Recovered in %v: %v", err, string(debug.Stack()))
 			panicChan <- *domain
 		}
 	}()
@@ -44,13 +44,13 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 	for while := true; while; while = !runOnce {
 		if looping {
 			// Sleep with interval
-			log.Debugf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
+			log.Debugf("Going to sleep, will start next checking in %d seconds...", handler.Configuration.Interval)
 			time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 		}
 
 		looping = true
 
-		log.Infof("Checking IP for domain %s \r\n", domain.DomainName)
+		log.Infof("Checking IP for domain %s", domain.DomainName)
 		domainID := handler.GetDomain(domain.DomainName)
 
 		if domainID == -1 {
@@ -81,26 +81,26 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 
 			//check against currently known IP, if no change, skip update
 			if currentIP == lastIP {
-				log.Infof("IP is the same as cached one (%s). Skip update.\n", currentIP)
+				log.Infof("IP is the same as cached one (%s). Skip update.", currentIP)
 			} else {
 				lastIP = currentIP
 
 				subDomainID, ip := handler.GetSubDomain(domainID, subDomain)
 
 				if subDomainID == "" || ip == "" {
-					log.Infof("Domain or subdomain not configured yet. domain: %s.%s subDomainID: %s ip: %s\n", subDomain, domain.DomainName, subDomainID, ip)
+					log.Infof("Domain or subdomain not configured yet. domain: %s.%s subDomainID: %s ip: %s", subDomain, domain.DomainName, subDomainID, ip)
 					continue
 				}
 
 				// Continue to check the IP of subdomain
 				if len(ip) > 0 && strings.TrimRight(currentIP, "\n") != strings.TrimRight(ip, "\n") {
-					log.Infof("%s.%s Start to update record IP...\n", subDomain, domain.DomainName)
+					log.Infof("%s.%s Start to update record IP...", subDomain, domain.DomainName)
 					handler.UpdateIP(domainID, subDomainID, subDomain, currentIP)
 
 					// Send notification
 					notify.GetNotifyManager(handler.Configuration).Send(fmt.Sprintf("%s.%s", subDomain, domain.DomainName), currentIP)
 				} else {
-					log.Infof("%s.%s Current IP is same as domain IP, no need to update...\n", subDomain, domain.DomainName)
+					log.Infof("%s.%s Current IP is same as domain IP, no need to update...", subDomain, domain.DomainName)
 				}
 			}
 		}
@@ -170,7 +170,7 @@ func (handler *Handler) GetDomain(name string) int64 {
 			log.Info("domains slice is empty.")
 		}
 	} else {
-		log.Info("get_domain:status code:", sjson.Get("status").Get("code").MustString())
+		log.Infof("get_domain:status code: %s", sjson.Get("status").Get("code").MustString())
 	}
 
 	return ret
@@ -223,7 +223,7 @@ func (handler *Handler) GetSubDomain(domainID int64, name string) (string, strin
 			log.Info("records slice is empty.")
 		}
 	} else {
-		log.Info("get_subdomain:status code:", sjson.Get("status").Get("code").MustString())
+		log.Infof("get_subdomain:status code: %s", sjson.Get("status").Get("code").MustString())
 	}
 
 	return ret, ip
@@ -265,7 +265,7 @@ func (handler *Handler) UpdateIP(domainID int64, subDomainID string, subDomainNa
 	if sjson.Get("status").Get("code").MustString() == "1" {
 		log.Info("New IP updated!")
 	} else {
-		log.Info("Failed to update IP record:", sjson.Get("status").Get("message").MustString())
+		log.Infof("Failed to update IP record: %s", sjson.Get("status").Get("message").MustString())
 	}
 
 }

--- a/internal/handler/dreamhost/dreamhost_handler.go
+++ b/internal/handler/dreamhost/dreamhost_handler.go
@@ -37,7 +37,7 @@ func (handler *Handler) SetConfiguration(conf *settings.Settings) {
 func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- settings.Domain, runOnce bool) {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Errorf("Recovered in %v: %v\n", err, string(debug.Stack()))
+			log.Errorf("Recovered in %v: %v", err, string(debug.Stack()))
 			panicChan <- *domain
 		}
 	}()
@@ -46,7 +46,7 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 	for while := true; while; while = !runOnce {
 		if looping {
 			// Sleep with interval
-			log.Debugf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
+			log.Debugf("Going to sleep, will start next checking in %d seconds...", handler.Configuration.Interval)
 			time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 		}
 		looping = true
@@ -69,9 +69,9 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 
 			//check against currently known IP, if no change, skip update
 			if currentIP == lastIP {
-				log.Infof("IP is the same as cached one (%s). Skip update.\n", currentIP)
+				log.Infof("IP is the same as cached one (%s). Skip update.", currentIP)
 			} else {
-				log.Infof("%s.%s Start to update record IP...\n", subDomain, domain.DomainName)
+				log.Infof("%s.%s Start to update record IP...", subDomain, domain.DomainName)
 				handler.UpdateIP(hostname, currentIP, lastIP)
 
 				// Send notification
@@ -116,7 +116,7 @@ func (handler *Handler) updateDNS(dns, ip, hostname, action string) {
 		values.Add("cmd", "dns-add_record")
 		values.Add("value", ip)
 	default:
-		log.Fatalf("Unknown action %s\n", action)
+		log.Fatalf("Unknown action %s", action)
 	}
 
 	client := utils.GetHttpClient(handler.Configuration, handler.Configuration.UseProxy)
@@ -133,9 +133,9 @@ func (handler *Handler) updateDNS(dns, ip, hostname, action string) {
 	} else {
 		body, _ := ioutil.ReadAll(resp.Body)
 		if resp.StatusCode == http.StatusOK {
-			log.Info("Update IP success:", string(body))
+			log.Infof("Update IP success: %s", string(body))
 		} else {
-			log.Info("Update IP failed:", string(body))
+			log.Infof("Update IP failed: %s", string(body))
 		}
 	}
 }

--- a/internal/handler/duck/duck_handler.go
+++ b/internal/handler/duck/duck_handler.go
@@ -33,7 +33,7 @@ func (handler *Handler) SetConfiguration(conf *settings.Settings) {
 func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- settings.Domain, runOnce bool) {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Errorf("Recovered in %v: %v\n", err, string(debug.Stack()))
+			log.Errorf("Recovered in %v: %v", err, string(debug.Stack()))
 			panicChan <- *domain
 		}
 	}()
@@ -43,7 +43,7 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 	for while := true; while; while = !runOnce {
 		if looping {
 			// Sleep with interval
-			log.Debugf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
+			log.Debugf("Going to sleep, will start next checking in %d seconds...", handler.Configuration.Interval)
 			time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 		}
 
@@ -75,7 +75,7 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 
 			//check against currently known IP, if no change, skip update
 			if currentIP == lastIP {
-				log.Infof("IP is the same as cached one (%s). Skip update.\n", currentIP)
+				log.Infof("IP is the same as cached one (%s). Skip update.", currentIP)
 			} else {
 				// update IP with HTTP GET request
 				resp, err := client.Get(fmt.Sprintf(DuckUrl, subDomain, handler.Configuration.LoginToken, ip))
@@ -92,7 +92,7 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 					log.Error("Failed to update the IP:", err)
 					continue
 				} else {
-					log.Info("IP updated to:", currentIP)
+					log.Infof("IP updated to: %s", currentIP)
 				}
 
 				// Send notification

--- a/internal/handler/dynv6/dynv6_handler.go
+++ b/internal/handler/dynv6/dynv6_handler.go
@@ -34,7 +34,7 @@ func (handler *Handler) SetConfiguration(conf *settings.Settings) {
 func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- settings.Domain, runOnce bool) {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Errorf("Recovered in %v: %v\n", err, string(debug.Stack()))
+			log.Errorf("Recovered in %v: %v", err, string(debug.Stack()))
 			panicChan <- *domain
 		}
 	}()
@@ -76,7 +76,7 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 				if err != nil {
 					log.Errorf("Failed to update domain %s: %v", hostname, err)
 				} else {
-					log.Info("IP updated to:", currentIP)
+					log.Infof("IP updated to: %s", currentIP)
 				}
 			}
 		}

--- a/internal/handler/google/google_handler.go
+++ b/internal/handler/google/google_handler.go
@@ -34,7 +34,7 @@ func (handler *Handler) SetConfiguration(conf *settings.Settings) {
 func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- settings.Domain, runOnce bool) {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Errorf("Recovered in %v: %v\n", err, string(debug.Stack()))
+			log.Errorf("Recovered in %v: %v", err, string(debug.Stack()))
 			panicChan <- *domain
 		}
 	}()
@@ -44,7 +44,7 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 	for while := true; while; while = !runOnce {
 		if looping {
 			// Sleep with interval
-			log.Debugf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
+			log.Debugf("Going to sleep, will start next checking in %d seconds...", handler.Configuration.Interval)
 			time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 		}
 
@@ -65,9 +65,9 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 
 			//check against currently known IP, if no change, skip update
 			if currentIP == lastIP {
-				log.Infof("IP is the same as cached one (%s). Skip update.\n", currentIP)
+				log.Infof("IP is the same as cached one (%s). Skip update.", currentIP)
 			} else {
-				log.Infof("%s.%s Start to update record IP...\n", subDomain, domain.DomainName)
+				log.Infof("%s.%s Start to update record IP...", subDomain, domain.DomainName)
 				handler.UpdateIP(domain.DomainName, subDomain, currentIP)
 
 				// Send notification
@@ -102,12 +102,12 @@ func (handler *Handler) UpdateIP(domain, subDomain, currentIP string) {
 		body, _ := ioutil.ReadAll(resp.Body)
 		if resp.StatusCode == http.StatusOK {
 			if strings.Contains(string(body), "good") {
-				log.Info("Update IP success:", string(body))
+				log.Infof("Update IP success: %s", string(body))
 			} else if strings.Contains(string(body), "nochg") {
-				log.Info("IP not changed:", string(body))
+				log.Infof("IP not changed: %s", string(body))
 			}
 		} else {
-			log.Info("Update IP failed:", string(body))
+			log.Infof("Update IP failed: %s", string(body))
 		}
 	}
 }

--- a/internal/handler/he/he_handler.go
+++ b/internal/handler/he/he_handler.go
@@ -35,7 +35,7 @@ func (handler *Handler) SetConfiguration(conf *settings.Settings) {
 func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- settings.Domain, runOnce bool) {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Errorf("Recovered in %v: %v\n", err, string(debug.Stack()))
+			log.Errorf("Recovered in %v: %v", err, string(debug.Stack()))
 			panicChan <- *domain
 		}
 	}()
@@ -44,7 +44,7 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 	for while := true; while; while = !runOnce {
 		if looping {
 			// Sleep with interval
-			log.Debugf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
+			log.Debugf("Going to sleep, will start next checking in %d seconds...", handler.Configuration.Interval)
 			time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 		}
 		looping = true
@@ -76,9 +76,9 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 
 			//check against currently known IP, if no change, skip update
 			if currentIP == lastIP {
-				log.Infof("IP is the same as cached one (%s). Skip update.\n", currentIP)
+				log.Infof("IP is the same as cached one (%s). Skip update.", currentIP)
 			} else {
-				log.Infof("%s.%s - Start to update record IP...\n", subDomain, domain.DomainName)
+				log.Infof("%s.%s - Start to update record IP...", subDomain, domain.DomainName)
 				handler.UpdateIP(domain.DomainName, subDomain, currentIP)
 
 				// Send notification
@@ -111,9 +111,9 @@ func (handler *Handler) UpdateIP(domain, subDomain, currentIP string) {
 	} else {
 		body, _ := ioutil.ReadAll(resp.Body)
 		if resp.StatusCode == http.StatusOK {
-			log.Info("Update IP success:", string(body))
+			log.Infof("Update IP success: %s", string(body))
 		} else {
-			log.Info("Update IP failed:", string(body))
+			log.Infof("Update IP failed: %s", string(body))
 		}
 	}
 }

--- a/internal/handler/linode/handler.go
+++ b/internal/handler/linode/handler.go
@@ -42,14 +42,14 @@ func createDNSClient(conf *settings.Settings) DNSClient {
 func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- settings.Domain, runOnce bool) {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Errorf("Recovered in %v: %v\n", err, string(debug.Stack()))
+			log.Errorf("Recovered in %v: %v", err, string(debug.Stack()))
 			panicChan <- *domain
 		}
 	}()
 
 	for while := true; while; while = !runOnce {
 		handler.domainLoop(domain)
-		log.Debugf("DNS update loop finished, will run again in %d seconds\r\n", handler.Configuration.Interval)
+		log.Debugf("DNS update loop finished, will run again in %d seconds", handler.Configuration.Interval)
 		time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 	}
 }
@@ -57,7 +57,7 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 func (handler *Handler) domainLoop(domain *settings.Domain) {
 	ip, err := utils.GetCurrentIP(handler.Configuration)
 	if err != nil {
-		log.Info(err)
+		log.Error(err)
 		return
 	}
 	if ip == handler.cachedIP {
@@ -66,7 +66,7 @@ func (handler *Handler) domainLoop(domain *settings.Domain) {
 	}
 	err = updateDNS(domain, ip, handler.client)
 	if err != nil {
-		log.Info(err)
+		log.Error(err)
 		return
 	}
 	handler.cachedIP = ip

--- a/internal/handler/noip/noip_handler.go
+++ b/internal/handler/noip/noip_handler.go
@@ -34,7 +34,7 @@ func (handler *Handler) SetConfiguration(conf *settings.Settings) {
 func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- settings.Domain, runOnce bool) {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Errorf("Recovered in %v: %v\n", err, string(debug.Stack()))
+			log.Errorf("Recovered in %v: %v", err, string(debug.Stack()))
 			panicChan <- *domain
 		}
 	}()
@@ -44,7 +44,7 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 	for while := true; while; while = !runOnce {
 		if looping {
 			// Sleep with interval
-			log.Debugf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
+			log.Debugf("Going to sleep, will start next checking in %d seconds...", handler.Configuration.Interval)
 			time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 		}
 
@@ -76,7 +76,7 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 
 			//check against currently known IP, if no change, skip update
 			if currentIP == lastIP {
-				log.Infof("IP is the same as cached one (%s). Skip update.\n", currentIP)
+				log.Infof("IP is the same as cached one (%s). Skip update.", currentIP)
 			} else {
 				req, _ := http.NewRequest("GET", fmt.Sprintf(
 					NoIPUrl,
@@ -104,7 +104,7 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 					log.Error("Failed to update the IP", err)
 					continue
 				} else {
-					log.Info("IP updated to:", currentIP)
+					log.Infof("IP updated to: %s", currentIP)
 				}
 
 				// Send notification

--- a/internal/handler/scaleway/scaleway_handler.go
+++ b/internal/handler/scaleway/scaleway_handler.go
@@ -66,7 +66,7 @@ func (handler *Handler) SetConfiguration(conf *settings.Settings) {
 func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- settings.Domain, runOnce bool) {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Errorf("Recovered in %v: %v\n", err, string(debug.Stack()))
+			log.Errorf("Recovered in %v: %v", err, string(debug.Stack()))
 			panicChan <- *domain
 		}
 	}()
@@ -75,7 +75,7 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 	for while := true; while; while = !runOnce {
 		if looping {
 			// Sleep with interval
-			log.Debugf("Going to sleep, will start next checking in %d seconds...\r\n", handler.Configuration.Interval)
+			log.Debugf("Going to sleep, will start next checking in %d seconds...", handler.Configuration.Interval)
 			time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 		}
 
@@ -104,9 +104,9 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 
 			// Check against currently known IP, if no change, skip update
 			if currentIP == lastIP {
-				log.Infof("IP is the same as cached one (%s). Skip update.\n", currentIP)
+				log.Infof("IP is the same as cached one (%s). Skip update.", currentIP)
 			} else {
-				log.Infof("%s.%s - Start to update record IP...\n", subDomain, domain.DomainName)
+				log.Infof("%s.%s - Start to update record IP...", subDomain, domain.DomainName)
 				err := handler.UpdateIP(domain.DomainName, subDomain, currentIP)
 				if err != nil {
 					log.Error(err)

--- a/pkg/notify/pushover.go
+++ b/pkg/notify/pushover.go
@@ -61,7 +61,7 @@ func (n *PushoverNotify) Send(domain, currentIP string) error {
 		form.Add("priority", strconv.FormatInt(int64(priority), 10))
 	}
 
-	log.Debugf("Pushover api request URL: %s, Form: %v\n", ReqURL, form)
+	log.Debugf("Pushover api request URL: %s, Form: %v", ReqURL, form)
 	response, err = client.PostForm(ReqURL, form)
 	if err != nil {
 		return err
@@ -83,7 +83,7 @@ func (n *PushoverNotify) Send(domain, currentIP string) error {
 		fmt.Println("error:", err)
 		return errors.New("failed to parse pushover api response")
 	}
-	log.Debugf("Pushover api response: %+v\n", resp)
+	log.Debugf("Pushover api response: %+v", resp)
 	if resp.Status != 1 {
 		return fmt.Errorf("pushover api call failed Status: %v, Errors: %v", resp.Status, resp.Errors)
 	}


### PR DESCRIPTION
- Removing unnecessary newline strings on log commands (`\n` and `\r\n`).
- Converting logging from string concatenation (`.Info`) to formatter logs (`.Infof`)
- Adding whitespace to crowded log lines

# Console example 
## Logging example to console *before*
```
INFO[0000] GoDNS started, entering main loop...
INFO[0000] Creating DNS handler with provider:Cloudflare
INFO[0000] Checking IP for domain domain.com
INFO[0003] Querying records with type:A
 NFO[0003] Record OK: vpn.domain.com - 0.0.0.0
```
Notice the missing `I` at INFO on last line and the crowded `provider:Cloudflare` and `type:A` log lines.

## *After*

```
INFO[0000] GoDNS started, entering main loop...
INFO[0000] Creating DNS handler with provider: Cloudflare
INFO[0000] Checking IP for domain domain.com
INFO[0001] Querying records with type: A
INFO[0001] Record OK: vpn.domain.com - 0.0.0.0
```

# File log example
## Log redirected to file *before*
```
time="2022-03-26T10:20:01+11:00" level=info msg="GoDNS started, entering main loop..."
time="2022-03-26T10:20:01+11:00" level=info msg="Creating DNS handler with provider:Cloudflare"
time="2022-03-26T10:20:02+11:00" level=info msg="Checking IP for domain domain.com"
time="2022-03-26T10:20:06+11:00" level=info msg="Querying records with type:A"
time="2022-03-26T10:20:08+11:00" level=info msg="Record OK: vpn.domain.com - 0.0.0.0\r\n"
```
Notice the invalid `\r\n` at the end of the log line

## *After*
```
time="2022-03-26T10:59:24+11:00" level=info msg="GoDNS started, entering main loop..."
time="2022-03-26T10:59:24+11:00" level=info msg="Creating DNS handler with provider: Cloudflare"
time="2022-03-26T10:59:25+11:00" level=info msg="Checking IP for domain domain.com"
time="2022-03-26T10:59:26+11:00" level=info msg="Querying records with type: A"
time="2022-03-26T10:59:26+11:00" level=info msg="Record OK: vpn.domain.com - 0.0.0.0"
```