### PR TITLE
Fix login_token_file

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -166,7 +166,7 @@ func loadSecretsFromFile(settings *Settings) error {
 		return fmt.Errorf("failed to load password from file: %w", err)
 	}
 
-	if settings.LoginTokenFile, err = readSecretFromFile(
+	if settings.LoginToken, err = readSecretFromFile(
 		settings.LoginTokenFile,
 		settings.LoginToken,
 	); err != nil {


### PR DESCRIPTION
There is a tiny mistake in pr #143 causing the setting `login_token_file` to break. cc @tboerger.