### PR TITLE
Fix checking private address

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -116,13 +116,7 @@ func GetIPFromInterface(configuration *settings.Settings) (string, error) {
 			continue
 		}
 
-		if !(ip.IsGlobalUnicast() &&
-			!(ip.IsUnspecified() ||
-				ip.IsMulticast() ||
-				ip.IsLoopback() ||
-				ip.IsLinkLocalUnicast() ||
-				ip.IsLinkLocalMulticast() ||
-				ip.IsInterfaceLocalMulticast())) {
+		if (ip.IsPrivate()) {
 			continue
 		}
 


### PR DESCRIPTION
The code of `GetIPFromInterface` has some problem with checking an address is a private address.
For example, the IPv6 address: `fd78:f12b:48f8:0:3c87:a0ff:fe32:ae07` which actually is a private address, will be returned from this function as a public address.

As in the offical docs for the `IsGlobalUnicast()` func: `It returns true even if ip is in IPv4 private address space or local IPv6 unicast address space.`

Since Golang has a more convenient function that can just check an address is private or not, we can just use it and remove the old logic.

It's tested on my machine, working well.

Hope the PR can be merged, thanks!