### PR TITLE
Work around wildcard subdomain filtering bug in linode API

### DIFF
--- a/internal/handler/linode/client.go
+++ b/internal/handler/linode/client.go
@@ -66,21 +66,19 @@ func (dnsClient *DNSClient) getDomainID(name string) (int, error) {
 }
 
 func (dnsClient *DNSClient) getDomainRecordID(domainID int, name string) (bool, int, error) {
-	f := linodego.Filter{}
-	f.AddField(linodego.Eq, "name", name)
-	fStr, err := f.MarshalJSON()
-	if err != nil {
-		log.Fatal(err)
-	}
-	opts := linodego.NewListOptions(0, string(fStr))
-	res, err := dnsClient.linodeClient.ListDomainRecords(context.Background(), domainID, opts)
+	res, err := dnsClient.linodeClient.ListDomainRecords(context.Background(), domainID, nil)
 	if err != nil {
 		return false, 0, err
 	}
 	if len(res) == 0 {
 		return false, 0, nil
 	}
-	return true, res[0].ID, nil
+	for _, record := range res {
+		if record.Name == name {
+			return true, record.ID, nil
+		}
+	}
+	return false, 0, nil
 }
 
 func (dnsClient *DNSClient) createDomainRecord(domainID int, name string) (int, error) {


### PR DESCRIPTION
This is a temporary fix for #146.

The Linode API should be able to be queried for data about a wildcard subdomain by using the [Domain Records List endpoint](https://www.linode.com/docs/api/domains/#domain-records-list) with the header `x-filter: {"name": "*"}` to filter the list of subdomains for the wildcard subdomain as part of the API call.

The API has a bug, though, specifically for the wildcard subdomain. The above query returns an empty list even when the wildcard subdomain exists. For GoDNS, this means a new wildcard subdomain is created every time the IP changes or the program is restarted because it can't find the existing wildcard subdomain.

This PR makes a small change: instead of asking for the API to filter the response, GoDNS instead asks for all subdomains and filters them itself.

I have an open ticket with Linode support about this. When Linode fixes the bug in the API we can revert this.

