### PR TITLE
Pull runOnce logic out of handler

### DIFF
--- a/cmd/godns/godns.go
+++ b/cmd/godns/godns.go
@@ -71,9 +71,9 @@ func dnsLoop() {
 	for _, domain := range configuration.Domains {
 		domain := domain
 		if configuration.RunOnce {
-			ddnsHandler.DomainLoop(&domain, panicChan, configuration.RunOnce)
+			ddnsHandler.UpdateIP(&domain)
 		} else {
-			go ddnsHandler.DomainLoop(&domain, panicChan, configuration.RunOnce)
+			go ddnsHandler.LoopUpdateIP(&domain, panicChan)
 		}
 	}
 
@@ -85,7 +85,7 @@ func dnsLoop() {
 	for {
 		failDomain := <-panicChan
 		log.Debug("Got panic in goroutine, will start a new one... :", panicCount)
-		go ddnsHandler.DomainLoop(&failDomain, panicChan, configuration.RunOnce)
+		go ddnsHandler.LoopUpdateIP(&failDomain, panicChan)
 
 		panicCount++
 		if panicCount >= utils.PanicMax {

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -31,7 +31,7 @@ func (handler *Handler) SetProvider(provider provider.IDNSProvider) {
 	handler.dnsProvider = provider
 }
 
-func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- settings.Domain, runOnce bool) {
+func (handler *Handler) LoopUpdateIP(domain *settings.Domain, panicChan chan<- settings.Domain) {
 	defer func() {
 		if err := recover(); err != nil {
 			log.Errorf("Recovered in %v: %v", err, string(debug.Stack()))
@@ -39,19 +39,14 @@ func (handler *Handler) DomainLoop(domain *settings.Domain, panicChan chan<- set
 		}
 	}()
 
-	for while := true; while; while = !runOnce {
-		handler.domainLoop(domain)
-
-		if runOnce {
-			break
-		}
-
+	for {
+		handler.UpdateIP(domain)
 		log.Debugf("DNS update loop finished, will run again in %d seconds", handler.Configuration.Interval)
 		time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 	}
 }
 
-func (handler *Handler) domainLoop(domain *settings.Domain) {
+func (handler *Handler) UpdateIP(domain *settings.Domain) {
 	ip, err := utils.GetCurrentIP(handler.Configuration)
 	if err != nil {
 		log.Error(err)


### PR DESCRIPTION
This PR presents a small refactor that pulls `runOnce` logic out of `Handler.DomainLoop` by exporting the single run `Handler.domainLoop` function. This requires a function rename to avoid a naming clash.