### PR TITLE
fix(run_once): in case of error, exit with code 1

### DIFF
--- a/cmd/godns/godns.go
+++ b/cmd/godns/godns.go
@@ -71,7 +71,11 @@ func dnsLoop() {
 	for _, domain := range configuration.Domains {
 		domain := domain
 		if configuration.RunOnce {
-			ddnsHandler.UpdateIP(&domain)
+			err := ddnsHandler.UpdateIP(&domain)
+			if err != nil {
+				log.Error("Error during execution:", err)
+				os.Exit(1)
+			}
 		} else {
 			go ddnsHandler.LoopUpdateIP(&domain, panicChan)
 		}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -46,7 +46,10 @@ func (handler *Handler) LoopUpdateIP(domain *settings.Domain, panicChan chan<- s
 	}()
 
 	for {
-		handler.UpdateIP(domain)
+		err := handler.UpdateIP(domain)
+		if err != nil {
+			log.WithError(err).Debug("Update IP failed during the DNS Update loop")
+		}
 		log.Debugf("DNS update loop finished, will run again in %d seconds", handler.Configuration.Interval)
 		time.Sleep(time.Second * time.Duration(handler.Configuration.Interval))
 	}


### PR DESCRIPTION
Hello :wave: 
In this PR I suggest to add an error to `run_once`, the idea is to know if godns exited correctly or not.
In addition, when an error occurred the godns command does not "freeze".

So it requires a little change on the `handler.LoopUpdateIP` signature.

_____________
I made this change on my fork about a month ago it met my need, I thought it might help others here.
_EDIT: I've updated the code to fit the current change_