### PR TITLE
Add send_from field to notify.mail config

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ Emails are sent over [SMTP](https://en.wikipedia.org/wiki/Simple_Mail_Transfer_P
       "smtp_username": "user",
       "smtp_password": "password",
       "smtp_port": 25,
+      "send_from": "my_mail@example.com"
       "send_to": "my_mail@example.com"
     }
   }

--- a/configs/config_sample.json
+++ b/configs/config_sample.json
@@ -43,6 +43,7 @@
       "smtp_username": "",
       "smtp_password": "",
       "smtp_port": 25,
+      "send_from": "",
       "send_to": ""
     }
   },

--- a/configs/config_sample.yaml
+++ b/configs/config_sample.yaml
@@ -28,6 +28,7 @@ notify:
     smtp_username:
     smtp_password:
     smtp_port: 25
+    send_from:
     send_to:
 webhook:
   enabled: false

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -53,6 +53,7 @@ type MailNotify struct {
 	SMTPPassword     string `json:"smtp_password" yaml:"smtp_password"`
 	SMTPPasswordFile string `json:"smtp_password_file" yaml:"smtp_password_file"`
 	SMTPPort         int    `json:"smtp_port" yaml:"smtp_port"`
+	SendFrom         string `json:"send_from" yaml:"send_from"`
 	SendTo           string `json:"send_to" yaml:"send_to"`
 }
 

--- a/pkg/notification/email.go
+++ b/pkg/notification/email.go
@@ -19,7 +19,12 @@ func (n *EmailNotification) Send(domain, currentIP string) error {
 	log.Debug("Sending notification to: ", n.conf.Notify.Mail.SendTo)
 	m := gomail.NewMessage()
 
-	m.SetHeader("From", n.conf.Notify.Mail.SMTPUsername)
+	if n.conf.Notify.Mail.SendFrom != "" {
+		m.SetHeader("From", n.conf.Notify.Mail.SendFrom)
+	} else {
+		log.Debug("'send_from' is not set, use 'smtp_username' instead")
+		m.SetHeader("From", n.conf.Notify.Mail.SMTPUsername)
+	}
 	m.SetHeader("To", n.conf.Notify.Mail.SendTo)
 	m.SetHeader("Subject", "GoDNS Notification")
 	log.Debug("currentIP:", currentIP)


### PR DESCRIPTION
Add new configuration field, notify.mail.send_from, that if set, is used as the "From:" e-mail field. If not set, the behaviour remains the same, that smtp_username is used as "From:" too, to be compatible with previous config files.

This solves the email notification issue where gomail fails to send the email because the smtp_username is not an e-mail address, e.g.:

  ERRO[0001] Send notification with error:gomail: could not send email
  1: gomail: invalid address "username": mail: missing '@' or angle-addr