### PR TITLE
chore: update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:alpine AS builder
 WORKDIR /godns
-ADD . /godns/
+ADD . .
 RUN CGO_ENABLED=0 go build -o godns cmd/godns/godns.go
 
 FROM gcr.io/distroless/base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM golang:alpine AS builder
-RUN mkdir /godns
-ADD . /godns/
 WORKDIR /godns
+ADD . /godns/
 RUN CGO_ENABLED=0 go build -o godns cmd/godns/godns.go
 
 FROM gcr.io/distroless/base


### PR DESCRIPTION
## What does this PR?
Tidy Dockerfile. The `WORKDIR` directive will create the dir and switch the current working directory to it by default. According to the [official docs](https://docs.docker.com/engine/reference/builder/#workdir):

> The WORKDIR instruction sets the working directory for any RUN, CMD, ENTRYPOINT, COPY and ADD instructions that follow it in the Dockerfile. If the WORKDIR doesn't exist, it will be created even if it's not used in any subsequent Dockerfile instruction.

Tested with docker build and docker run:
```bash
➜  godns git:(dockerfile-tidy) docker run -d --name godns --restart=always -v ./config.json:/config.json docker.io/library/godns
321bd5715676b4efa0d7146f6f89e01606120489aed3fbff0a1aba29bb4c6921
```