### PR TITLE
修复错误的ipv6_urls并精确ipv4获取url

### DIFF
--- a/configs/config_sample.json
+++ b/configs/config_sample.json
@@ -13,14 +13,16 @@
     }
   ],
   "ip_urls": [
-    "https://api.ipify.org",
+    "https://api4.ipify.org",
     "https://myip.biturl.top",
     "https://ip4.seeip.org",
     "https://ipecho.net/plain",
-    "https://api-ipv4.ip.sb/ip",
-    "https://api.ip.sb/ip"
+    "https://api-ipv4.ip.sb/ip"
   ],
-  "ipv6_urls": ["https://ipify.org"],
+  "ipv6_urls": [
+    "https://api6.ipify.org",
+    "https://api-ipv6.ip.sb/ip"
+    ],
   "ip_type": "IPv4",
   "interval": 300,
   "resolver": "8.8.8.8",

--- a/configs/config_sample.yaml
+++ b/configs/config_sample.yaml
@@ -6,8 +6,8 @@ domains:
     sub_domains:
       - www
       - test
-ip_urls: [https://api.ipify.org, https://api.ip.sb/ip]
-ipv6_urls: [https://ipify.org]
+ip_urls: [https://api4.ipify.org, https://api-ipv4.ip.sb/ip]
+ipv6_urls: [https://api6.ipify.org, https://api-ipv6.ip.sb/ip]
 ip_type: IPv4
 interval: 300
 resolver: 8.8.8.8


### PR DESCRIPTION
原本ipv6的`https://ipify.org`错误，无法获取正常ip
部分ip_urls会获取到ipv6的地址，如`https://api.ip.sb/ip`，现改为获取ipv4的地址