### PR TITLE
Add option to skip verification of ssl certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ By default, GoDNS uses `JSON` config file. However, you can specify to use the `
 - `interval` — How often (in seconds) the public IP should be updated.
 - `socks5_proxy` — Socks5 proxy server.
 - `resolver` — Address of a public DNS server to use. For instance to use [Google's public DNS](https://developers.google.com/speed/public-dns/docs/using), you can set `8.8.8.8` when using GoDNS in IPv4 mode or `2001:4860:4860::8888` in IPv6 mode.
+- `skip_ssl_verify` - Skip verification of ssl certificates for https requests.
 
 ### Update root domain
 

--- a/configs/config_sample.json
+++ b/configs/config_sample.json
@@ -32,6 +32,7 @@
   "use_proxy": false,
   "debug_info": false,
   "proxied": false,
+  "skip_ssl_verify": false,
   "notify": {
     "telegram": {
       "enabled": false,

--- a/configs/config_sample.yaml
+++ b/configs/config_sample.yaml
@@ -16,6 +16,7 @@ ip_interface: eth0
 socks5_proxy:
 use_proxy: false
 debug_info: false
+skip_ssl_verify: false
 notify:
   telegram:
     enabled: false

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -121,6 +121,7 @@ type Settings struct {
 	AppKey         string   `json:"app_key" yaml:"app_key"`
 	AppSecret      string   `json:"app_secret" yaml:"app_secret"`
 	ConsumerKey    string   `json:"comsumer_key" yaml:"comsumer_key"`
+	SkipSSLVerify  bool     `json:"skip_ssl_verify" yaml:"skip_ssl_verify"`
 }
 
 // LoadSettings -- Load settings from config file.

--- a/internal/utils/http.go
+++ b/internal/utils/http.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"crypto/tls"
 	"net"
 	"net/http"
 	"time"
@@ -31,9 +32,16 @@ func GetHTTPClient(conf *settings.Settings) *http.Client {
 			return dialer.Dial(network, address)
 		}
 
-		httpTransport := &http.Transport{}
+		httpTransport := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: conf.SkipSSLVerify},
+		}
 		client.Transport = httpTransport
 		httpTransport.DialContext = dialContext
+	} else {
+		httpTransport := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: conf.SkipSSLVerify},
+		}
+		client.Transport = httpTransport
 	}
 
 	return client


### PR DESCRIPTION
Some environments uses and IOT devices have limited to no root certificates causing verification of ssl certificates to become problematic.