### PR TITLE
Fix Cloudflare AAAA creation

### DIFF
--- a/internal/provider/cloudflare/cloudflare_handler.go
+++ b/internal/provider/cloudflare/cloudflare_handler.go
@@ -226,8 +226,16 @@ func (provider *DNSProvider) getDNSRecords(zoneID string) []DNSRecord {
 }
 
 func (provider *DNSProvider) createRecord(zoneID, domain, subDomain, ip string) error {
+	var recordType string
+
+	if provider.configuration.IPType == "" || strings.ToUpper(provider.configuration.IPType) == utils.IPV4 {
+		recordType = utils.IPTypeA
+	} else if strings.ToUpper(provider.configuration.IPType) == utils.IPV6 {
+		recordType = utils.IPTypeAAAA
+	}
+
 	newRecord := DNSRecord{
-		Type: utils.IPTypeA,
+		Type: recordType,
 		IP:   ip,
 		TTL:  1,
 	}


### PR DESCRIPTION
When running godns with Cloudflare and IPv6 mode. The creation of AAAA record failed, because the record type was hardcoded to A. 

With this pull request the record creation takes the configured IP type into consideration.