### PR TITLE
Added ipinfo.io endpoint for public IP

### DIFF
--- a/configs/config_sample.json
+++ b/configs/config_sample.json
@@ -23,12 +23,14 @@
     "https://myip.biturl.top",
     "https://ipecho.net/plain",
     "https://api-ipv4.ip.sb/ip",
-    "https://ip2location.io/ip"
+    "https://ip2location.io/ip",
+    "https://ipinfo.io/ip"
   ],
   "ipv6_urls": [
     "https://api6.ipify.org",
     "https://api-ipv6.ip.sb/ip",
-    "https://ip2location.io/ip"
+    "https://ip2location.io/ip",
+    "https://v6.ipinfo.io/ip"
   ],
   "ip_type": "IPv4",
   "interval": 300,

--- a/configs/config_sample.yaml
+++ b/configs/config_sample.yaml
@@ -6,8 +6,8 @@ domains:
     sub_domains:
       - www
       - test
-ip_urls: [https://api4.ipify.org, https://api-ipv4.ip.sb/ip, https://ip2location.io/ip]
-ipv6_urls: [https://api6.ipify.org, https://api-ipv6.ip.sb/ip, https://ip2location.io/ip]
+ip_urls: [https://api4.ipify.org, https://api-ipv4.ip.sb/ip, https://ip2location.io/ip, "https://ipinfo.io/ip"]
+ipv6_urls: [https://api6.ipify.org, https://api-ipv6.ip.sb/ip, https://ip2location.io/ip, "https://v6.ipinfo.io/ip"]
 ip_type: IPv4
 interval: 300
 resolver: 8.8.8.8


### PR DESCRIPTION
IPinfo returns the public IP response through the `/ip` endpoint.

- IPv4 endpoint: `https://ipinfo.io/ip`
- IPv6 endpoint: `https://v6.ipinfo.io/ip`