### PR TITLE
Add OpenWRT procd service script

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
   - [As a manual daemon](#as-a-manual-daemon)
   - [As a managed daemon (with upstart)](#as-a-managed-daemon-with-upstart)
   - [As a managed daemon (with systemd)](#as-a-managed-daemon-with-systemd)
+  - [As a managed daemon (with procd)](#as-a-managed-daemon-with-procd)
   - [As a Docker container](#as-a-docker-container)
   - [As a Windows service](#as-a-windows-service)
 - [Contributing](#contributing)
@@ -1165,6 +1166,17 @@ Note: when the program stops, it will not be restarted.
    ```bash
    sudo systemctl enable godns
    sudo systemctl start godns
+   ```
+
+### As a managed daemon (with procd)
+
+`procd` is the init system on OpenWRT. If you want to use godns as a service with OpenWRT and procd:
+1. Copy `./config/procd/godns` to `/etc/init.d` (and tweak it to your needs)
+2. Start the service (with root privilege):
+
+   ```bash
+   service godns enable
+   service godns start
    ```
 
 ### As a Docker container

--- a/configs/procd/godns
+++ b/configs/procd/godns
@@ -1,0 +1,21 @@
+#!/bin/sh /etc/rc.common
+
+# Put this script at /etc/init.d/godns
+# To start: `service godns start`
+# To enable (i.e. auto-start on boot): `service godns enable`
+
+USE_PROCD=1
+START=98
+PROG="/path/to/your/godns-dir/godns"
+CONF="/path/to/your/godns-dir/config.json"
+
+start_service() {
+        procd_open_instance
+        procd_set_param command "$PROG"
+        procd_append_param command -c="$CONF"
+        #procd_set_param stdout 1 # if enabled, log will go into syslog
+        procd_set_param stderr 1
+        procd_set_param respawn 600 10 10
+        procd_close_instance
+}
+


### PR DESCRIPTION
[procd](https://github.com/openwrt/procd) is the init system and service management system of [OpenWRT](https://openwrt.org/).

This PR adds the service script for OpenWRT's procd, at `configs/procd`, so that OpenWRT users can easily run `godns` daemon by `service godns start`.