### PR TITLE
Expand env vars in secret file paths

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -286,7 +286,7 @@ func readSecretFromFile(source, value string) (string, error) {
 		return value, nil
 	}
 
-	content, err := os.ReadFile(source)
+	content, err := os.ReadFile(os.ExpandEnv(source))
 
 	if err != nil {
 		return value, err

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"os"
 	"testing"
 )
 
@@ -32,6 +33,50 @@ func TestLoadYAMLSetting(t *testing.T) {
 
 	if len(settings.IPUrls) == 0 && settings.IPUrl == "" {
 		t.Fatal("cannot load ip_url from config file")
+	}
+
+	t.Log(settings)
+}
+
+func TestLoadWithEnvPath(t *testing.T) {
+	const expectedToken = "super secret login token"
+
+	tokenFile, err := os.CreateTemp("", "login_token_*.txt")
+	if err != nil {
+		t.Fatalf("failed to create temp token file: %v", err)
+	}
+	defer os.Remove(tokenFile.Name())
+
+	if _, err := tokenFile.WriteString(expectedToken); err != nil {
+		t.Fatalf("failed to write token to file: %v", err)
+	}
+	if err := tokenFile.Close(); err != nil {
+		t.Fatalf("failed to close token file: %v", err)
+	}
+
+	settings := Settings{
+		LoginTokenFile: "$LOGIN_TOKEN_FILE",
+	}
+
+	configFile, err := os.CreateTemp("", "config_*.yaml")
+	if err != nil {
+		t.Fatalf("failed to create temp config file: %v", err)
+	}
+	defer os.Remove(configFile.Name())
+
+	if err := settings.SaveSettings(configFile.Name()); err != nil {
+		t.Fatalf("failed to save settings to config file: %v", err)
+	}
+
+	t.Setenv("LOGIN_TOKEN_FILE", tokenFile.Name())
+
+	var loaded Settings
+	if err := LoadSettings(configFile.Name(), &loaded); err != nil {
+		t.Fatalf("failed to load settings with env var: %v", err)
+	}
+
+	if loaded.LoginToken != expectedToken {
+		t.Errorf("expected login token %q, got %q", expectedToken, loaded.LoginToken)
 	}
 
 	t.Log(settings)


### PR DESCRIPTION
This PR fixes #269 by expanding environment variables in secret file paths (e.g., `$CREDENTIALS_DIRECTORY/login_token`) before reading their contents. This enables compatibility with `systemd`'s `LoadCredential` feature and similar setups.
