### PR TITLE
fix(README.md): amend closing tag of details under transip

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,7 +893,7 @@ interval: 300
 socks5_proxy: ""
 ```
 
-<details>
+</details>
 
 ### Notifications
 


### PR DESCRIPTION
The notifications and special thanks sections etc. of the README were hidden as the `<details>` tag under the TransIP documentation was not properly closed.