### PR TITLE
Add configuration option to control private IP handling

### DIFF
--- a/configs/config_multi_sample.json
+++ b/configs/config_multi_sample.json
@@ -53,6 +53,7 @@
   "resolver": "8.8.8.8",
   "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.111 Safari/537.36",
   "ip_interface": "eth0",
+  "allow_private": false,
   
   "mikrotik": {
     "enabled": false,

--- a/configs/config_multi_sample.yaml
+++ b/configs/config_multi_sample.yaml
@@ -46,6 +46,7 @@ interval: 300
 resolver: 8.8.8.8
 user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.111 Safari/537.36"
 ip_interface: eth0
+allow_private: false
 
 mikrotik:
   enabled: false

--- a/configs/config_sample.json
+++ b/configs/config_sample.json
@@ -31,6 +31,7 @@
   "resolver": "8.8.8.8",
   "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.111 Safari/537.36",
   "ip_interface": "eth0",
+  "allow_private": false,
   "mikrotik": {
     "enabled": false,
     "addr": "http://192.168.88.1:81",

--- a/configs/config_sample.yaml
+++ b/configs/config_sample.yaml
@@ -25,6 +25,7 @@ interval: 300
 resolver: 8.8.8.8
 user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.111 Safari/537.36"
 ip_interface: eth0
+allow_private: false
 mikrotik:
   enabled: false
   addr: "http://192.168.20.1:81"

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -172,13 +172,14 @@ type Settings struct {
 	Domains []Domain `json:"domains" yaml:"domains"`
 
 	// Network and IP configuration
-	IPUrl       string   `json:"ip_url" yaml:"ip_url"`
-	IPUrls      []string `json:"ip_urls" yaml:"ip_urls"`
-	IPV6Url     string   `json:"ipv6_url" yaml:"ipv6_url"`
-	IPV6Urls    []string `json:"ipv6_urls" yaml:"ipv6_urls"`
-	IPInterface string   `json:"ip_interface" yaml:"ip_interface"`
-	IPType      string   `json:"ip_type" yaml:"ip_type"`
-	Resolver    string   `json:"resolver" yaml:"resolver"`
+	IPUrl        string   `json:"ip_url" yaml:"ip_url"`
+	IPUrls       []string `json:"ip_urls" yaml:"ip_urls"`
+	IPV6Url      string   `json:"ipv6_url" yaml:"ipv6_url"`
+	IPV6Urls     []string `json:"ipv6_urls" yaml:"ipv6_urls"`
+	IPInterface  string   `json:"ip_interface" yaml:"ip_interface"`
+	AllowPrivate bool     `json:"allow_private" yaml:"allow_private"`
+	IPType       string   `json:"ip_type" yaml:"ip_type"`
+	Resolver     string   `json:"resolver" yaml:"resolver"`
 
 	// Application configuration
 	Interval      int    `json:"interval" yaml:"interval"`

--- a/pkg/lib/ip_helper.go
+++ b/pkg/lib/ip_helper.go
@@ -220,7 +220,7 @@ func (helper *IPHelper) getIPFromInterface() (string, error) {
 			continue
 		}
 
-		if ip.IsPrivate() {
+		if !helper.configuration.AllowPrivate && ip.IsPrivate() {
 			continue
 		}
 


### PR DESCRIPTION
This pull request introduces a new configuration option, `allow_private`, which controls whether private IP addresses are permitted when resolving IPs from network interfaces. The change is reflected in both the application's configuration files and the logic that determines which IPs are considered valid.

Configuration updates:

* Added the `allow_private` option to the `Settings` struct in `internal/settings/settings.go` to enable or disable the use of private IP addresses.
* Updated all sample configuration files (`config_sample.json`, `config_sample.yaml`, `config_multi_sample.json`, `config_multi_sample.yaml`) to include the new `allow_private` field, defaulting to `false`. [[1]](diffhunk://#diff-be4905067dc435b195f4960739830c94589e6905739081a5da78aa83fb3fdab5R34) [[2]](diffhunk://#diff-4fbd93a3b50e8eede275fac0743f6e0fe870a386320290aad879f937b9cc1e8aR28) [[3]](diffhunk://#diff-cec743896daae9e16de565a4f1e8892682839a602fe40a08f9f618ca63a0d6f0R56) [[4]](diffhunk://#diff-d72d04e9721547003367dba0c82c8926446124291fd012a3d24c336609e3edb6R49)

IP address selection logic:

* Modified the `getIPFromInterface` function in `pkg/lib/ip_helper.go` to respect the `allow_private` configuration: if `allow_private` is `false`, private IPs are skipped when selecting an IP address.